### PR TITLE
Update multiple-emails.css

### DIFF
--- a/multiple-emails.css
+++ b/multiple-emails.css
@@ -12,6 +12,7 @@
 	outline: none; 
 	margin-bottom:3px; 
 	padding-left: 5px; 
+	box-sizing: border-box;
 }
 
 .multiple_emails-container input.multiple_emails-error {	


### PR DESCRIPTION
Added "box-sizing: border-box;" CSS so the text input device doesn't cause a strange white space gap in the border of the email container. This is due to the "5px padding" adding extra width to the "100%" width of the textbox. The solution is to change the calculation of the width via box-sizing property.
